### PR TITLE
Fix download via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and work out of the box.
 
    ```
    mkdir /tmp/codeintel
-   pip download /tmp/codeintel codeintel==0.9.3
+   pip download -d /tmp/codeintel codeintel==0.9.3
    ```
 
 6. Install codeintel


### PR DESCRIPTION
pip requires the additional flag ```-d``` to download a package into a custom directory

https://pip.pypa.io/en/stable/reference/pip_download/#cmdoption-d